### PR TITLE
Update temporary

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yate": ">=0.0.72"
   },
   "dependencies": {
-    "temporary": "0.0.5"
+    "temporary": "0.0.8"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Old `temporary` doesn't work with node 0.12, so it needs to be updated.
